### PR TITLE
MFW-6300 Added events service for publishing the event

### DIFF
--- a/services/events/events.go
+++ b/services/events/events.go
@@ -1,0 +1,54 @@
+// Package events provides a service for alert publishing on a ZMQ socket.
+// Usage:
+// 		events.Startup(logger) // this is just so it initializes the publisher on service Startup, not on the first call
+// 		events.Publisher().Send(alert1)
+// 		events.Publisher().Send(alert2)
+//		...
+//		events.Shutdown()
+
+package events
+
+import "github.com/untangle/golang-shared/logger"
+
+// AlertZMQTopic Topic name to be used when sending alerts.
+const EventZMQTopic string = "arista:reportd:alert"
+
+const PublisherSocketAddress = "ipc:///var/zmq_event_publisher"
+const SubscriberSocketAddress = "ipc:///var/zmq_event_subscriber"
+
+// ZmqMessage is a message sent over a zmq bus for us to consume.
+type ZmqMessage struct {
+	Topic   string
+	Message []byte
+}
+
+var publisher EventPublisher
+
+// Publisher returns the Publisher singleton.
+func Publisher(logger logger.LoggerLevels) EventPublisher {
+	if publisher == nil {
+		zmqPublisher := NewZmqEventPublisher(logger)
+		_ = zmqPublisher.Startup()
+
+		publisher = zmqPublisher
+	}
+
+	return publisher
+}
+
+// Startup is called when the service that uses Events starts
+func Startup(logger logger.LoggerLevels) {
+	logger.Info("Starting up the Events service\n")
+	Publisher(logger)
+}
+
+// Shutdown is called when the service that uses Events stops
+func Shutdown() {
+	if publisher == nil {
+		return
+	}
+
+	var zmqPublisher interface{} = Publisher(nil)
+	_ = zmqPublisher.(*ZmqEventPublisher).Shutdown()
+	publisher = nil
+}

--- a/services/events/events.go
+++ b/services/events/events.go
@@ -11,9 +11,8 @@ package events
 import "github.com/untangle/golang-shared/logger"
 
 const (
-	// AlertZMQTopic Topic name to be used when sending alerts.
-	ZMQTopicRestdEvents     = "arista:restd:alert"
-	ZMQTopicPakcetdEvents   = "arista:packetd:alert"
+	// AlertZMQTopic Topic is used for sending events from rest/packetd to reportd
+	AlertZMQTopic           = "arista:reportd:alerts"
 	sessionsZMQTopic        = "untangle:packetd:sessions"
 	interfaceStatsZMQTopic  = "untangle:packetd:interface-stats"
 	sessionStatsZMQTopic    = "untangle:packetd:session-stats"

--- a/services/events/events.go
+++ b/services/events/events.go
@@ -10,11 +10,18 @@ package events
 
 import "github.com/untangle/golang-shared/logger"
 
-// AlertZMQTopic Topic name to be used when sending alerts.
-const EventZMQTopic string = "arista:reportd:alert"
-
-const PublisherSocketAddress = "ipc:///var/zmq_event_publisher"
-const SubscriberSocketAddress = "ipc:///var/zmq_event_subscriber"
+const (
+	// AlertZMQTopic Topic name to be used when sending alerts.
+	ZMQTopicRestdEvents     = "arista:restd:alert"
+	ZMQTopicPakcetdEvents   = "arista:packetd:alert"
+	sessionsZMQTopic        = "untangle:packetd:sessions"
+	interfaceStatsZMQTopic  = "untangle:packetd:interface-stats"
+	sessionStatsZMQTopic    = "untangle:packetd:session-stats"
+	activeSessionsZMQTopic  = "untangle:packetd:active-sessions"
+	dosEventsZMQTopic       = "untangle:packetd:dos-events"
+	PublisherSocketAddress  = "ipc:///var/zmq_event_publisher"
+	SubscriberSocketAddress = "ipc:///var/zmq_event_subscriber"
+)
 
 // ZmqMessage is a message sent over a zmq bus for us to consume.
 type ZmqMessage struct {

--- a/services/events/mock_events.go
+++ b/services/events/mock_events.go
@@ -1,0 +1,48 @@
+package mocks
+
+import (
+	"sync"
+
+	protoAlerts "github.com/untangle/golang-shared/structs/protocolbuffers/Alerts"
+	"google.golang.org/protobuf/proto"
+)
+
+// MockEventPublisher is a test stub that keeps all the Alerts,
+// Events, last alert, last Event that were sent to it.
+type MockEventPublisher struct {
+	sync.Mutex
+	Alerts    []*protoAlerts.Alert
+	Events    []*ZmqMessage
+	LastAlert *protoAlerts.Alert
+	LastEvent *ZmqMessage
+}
+
+func (m *MockEventPublisher) Send(alert *protoAlerts.Alert) {
+	m.Lock()
+	defer m.Unlock()
+	m.LastAlert = alert
+	m.Alerts = append(m.Alerts, alert)
+}
+
+func (m *MockEventPublisher) SendZmqMessage(event *ZmqMessage) {
+	m.Lock()
+	defer m.Unlock()
+	m.LastEvent = event
+	m.Events = append(m.Events, event)
+}
+
+// GetLastAlert gets the last alert.
+func (m *MockEventPublisher) GetLastAlert() *protoAlerts.Alert {
+	m.Lock()
+	defer m.Unlock()
+	copy := proto.Clone(m.LastAlert)
+	return copy.(*protoAlerts.Alert)
+}
+
+// GetLastEvent gets the last event.
+func (m *MockEventPublisher) GetLastEvent() *ZmqMessage {
+	m.Lock()
+	defer m.Unlock()
+	copy := *m.LastEvent
+	return &copy
+}

--- a/services/events/mock_events.go
+++ b/services/events/mock_events.go
@@ -1,4 +1,4 @@
-package mocks
+package events
 
 import (
 	"sync"

--- a/services/events/publish.go
+++ b/services/events/publish.go
@@ -16,7 +16,7 @@ var EventPublisherSingleton *ZmqEventPublisher
 var once sync.Once
 
 type EventPublisher interface {
-	Send(alert *ZmqMessage)
+	Send(msg *ZmqMessage)
 }
 
 // ZmqEventPublisher runs a ZMQ publisher socket in the background.

--- a/services/events/publish.go
+++ b/services/events/publish.go
@@ -1,7 +1,6 @@
 package events
 
 import (
-	"fmt"
 	"sync"
 	"sync/atomic"
 
@@ -100,8 +99,6 @@ func (publisher *ZmqEventPublisher) Send(event *ZmqMessage) {
 		return
 	}
 
-	fmt.Printf("sending event: %s\n", event.Topic)
-
 	// send event directly on messagePublisherChannel
 	publisher.messagePublisherChannel <- *event
 }
@@ -125,7 +122,6 @@ func (publisher *ZmqEventPublisher) zmqPublisher() {
 	for {
 		select {
 		case msg := <-publisher.messagePublisherChannel:
-			fmt.Printf("Received event: %s and message: %v\n", msg.Topic, msg)
 			sentBytes, err := socket.SendMessage(msg.Topic, msg.Message)
 			if err != nil {
 				publisher.logger.Err("Publisher Send error: %s\n", err)

--- a/services/events/publish.go
+++ b/services/events/publish.go
@@ -1,0 +1,175 @@
+package events
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+
+	loggerModel "github.com/untangle/golang-shared/logger"
+
+	zmq "github.com/pebbe/zmq4"
+	"github.com/untangle/golang-shared/structs/protocolbuffers/Alerts"
+	"google.golang.org/protobuf/proto"
+)
+
+const messageBuffer = 1000
+
+var EventPublisherSingleton *ZmqEventPublisher
+var once sync.Once
+
+type EventPublisher interface {
+	Send(alert *Alerts.Alert)
+}
+
+// ZmqEventPublisher runs a ZMQ publisher socket in the background.
+// When the Send method is called the Events is passed down to the
+// ZMQ socket using a chanel and the message is published to ZMQ
+// using the Events specific topic.
+type ZmqEventPublisher struct {
+	logger                  loggerModel.LoggerLevels
+	messagePublisherChannel chan ZmqMessage
+	zmqPublisherShutdown    chan bool
+	zmqPublisherStarted     chan int32
+	socketAddress           string
+	started                 int32
+}
+
+func (publisher *ZmqEventPublisher) Name() string {
+	return "Event publisher"
+}
+
+// NewZmqEventPublisher Gets the singleton instance of ZmqEventPublisher.
+func NewZmqEventPublisher(logger loggerModel.LoggerLevels) *ZmqEventPublisher {
+	once.Do(func() {
+		EventPublisherSingleton = &ZmqEventPublisher{
+			logger:                  logger,
+			messagePublisherChannel: make(chan ZmqMessage, messageBuffer),
+			zmqPublisherShutdown:    make(chan bool),
+			zmqPublisherStarted:     make(chan int32, 1),
+			socketAddress:           PublisherSocketAddress,
+		}
+	})
+
+	return EventPublisherSingleton
+}
+
+func NewDefaultEventPublisher(logger loggerModel.LoggerLevels) EventPublisher {
+	return NewZmqEventPublisher(logger)
+}
+
+// Startup starts the ZMQ publisher in the background.
+func (publisher *ZmqEventPublisher) Startup() error {
+	publisher.logger.Info("Starting up the Events service\n")
+
+	// Make sure it is not started twice.
+	if atomic.LoadInt32(&publisher.started) > 0 {
+		publisher.logger.Debug("Events service is already running.\n")
+		return nil
+	}
+
+	go publisher.zmqPublisher()
+
+	// Blocks until the publisher starts.
+	atomic.AddInt32(&publisher.started, <-publisher.zmqPublisherStarted)
+
+	return nil
+}
+
+// Shutdown stops the goroutine running the ZMQ subscriber and closes the channels used in the service.
+func (publisher *ZmqEventPublisher) Shutdown() error {
+	publisher.logger.Info("Shutting down the Events service\n")
+
+	// Make sure it is not shutdown twice.
+	if atomic.LoadInt32(&publisher.started) == 0 {
+		publisher.logger.Debug("Events service is already shutdown.\n")
+		return nil
+	}
+
+	publisher.zmqPublisherShutdown <- true
+	close(publisher.zmqPublisherShutdown)
+	close(publisher.zmqPublisherStarted)
+	close(publisher.messagePublisherChannel)
+	atomic.StoreInt32(&publisher.started, 0)
+
+	return nil
+}
+
+// Send publishes the event to on the ZMQ publishing socket.
+func (publisher *ZmqEventPublisher) Send(event *Alerts.Alert) {
+	// Make sure it is not shutdown.
+	if atomic.LoadInt32(&publisher.started) == 0 {
+		publisher.logger.Debug("Events service has been shutdown.\n")
+		return
+	}
+
+	// 2 reasons to set the timestamp here:
+	// - the caller isn't responsible for setting the timestamp so we just need to set it in one place (here)
+	// - we set it before putting it in queue, which means we have the timestamp of the Events creation, not the timestamp when it was processed
+	event.Datetime = time.Now().Unix()
+
+	publisher.logger.Debug("Publish Events %v\n", event)
+	eventMessage, err := proto.Marshal(event)
+	if err != nil {
+		publisher.logger.Err("Unable to marshal Events entry: %s\n", err)
+		return
+	}
+
+	publisher.messagePublisherChannel <- ZmqMessage{Topic: EventZMQTopic, Message: eventMessage}
+}
+
+// zmqPublisher initializes a ZMQ publishing socket and listens on the
+// messagePublisherChannel. The received messages are published to the
+// ZMQ publisher socket.
+//
+// This method should be run as a goroutine. The goroutine can be stopped
+// by sending a message on the zmqPublisherShutdown channel.
+func (publisher *ZmqEventPublisher) zmqPublisher() {
+	socket, err := publisher.setupZmqPubSocket()
+	if err != nil {
+		publisher.logger.Warn("Unable to setup ZMQ publisher socket: %s\n", err)
+		return
+	}
+	defer socket.Close()
+
+	publisher.zmqPublisherStarted <- 1
+
+	for {
+		select {
+		case msg := <-publisher.messagePublisherChannel:
+			sentBytes, err := socket.SendMessage(msg.Topic, msg.Message)
+			if err != nil {
+				publisher.logger.Err("Publisher Send error: %s\n", err)
+				continue
+			}
+			publisher.logger.Debug("Message sent: %v bytes\n", sentBytes)
+		case <-publisher.zmqPublisherShutdown:
+			publisher.logger.Info("ZMQ Publisher shutting down\n")
+			return
+		}
+	}
+}
+
+// setupZmqPubSocket sets up the ZMQ socket for publishing events
+func (publisher *ZmqEventPublisher) setupZmqPubSocket() (soc *zmq.Socket, err error) {
+	publisher.logger.Info("Setting up Events ZMQ publisher socket...\n")
+
+	socket, err := zmq.NewSocket(zmq.PUB)
+	if err != nil {
+		publisher.logger.Err("Unable to open ZMQ publisher socket: %s\n", err)
+		return nil, err
+	}
+
+	if err = socket.SetLinger(0); err != nil {
+		publisher.logger.Err("Unable to SetLinger on ZMQ publisher socket: %s\n", err)
+		return nil, err
+	}
+
+	if err = socket.Connect(publisher.socketAddress); err != nil {
+		publisher.logger.Err("Unable to bind to ZMQ socket: %s\n", err)
+		return nil, err
+	}
+
+	publisher.logger.Info("Events ZMQ Publisher started!\n")
+
+	return socket, nil
+}

--- a/services/events/publish_test.go
+++ b/services/events/publish_test.go
@@ -1,0 +1,92 @@
+package events
+
+import (
+	"fmt"
+	"testing"
+
+	zmq "github.com/pebbe/zmq4"
+	"github.com/stretchr/testify/assert"
+	"github.com/untangle/golang-shared/structs/protocolbuffers/Alerts"
+	"github.com/untangle/golang-shared/testing/mocks"
+	"google.golang.org/protobuf/proto"
+)
+
+const testSocketAddress = "inproc://testInProcDescriptor"
+
+func TestEventPublisher(t *testing.T) {
+	//Set up
+	handler := newTestAlertHandler()
+	startupErr := handler.Startup()
+	assert.Nil(t, startupErr, "Failed to startup Zmq publisher in background")
+
+	subscriberSocket, err := createTestSubscriberSocket(testSocketAddress)
+	assert.Nil(t, err)
+
+	t.Run("send message", func(t *testing.T) {
+		testParam := Alerts.Alert{
+			Type:     Alerts.AlertType_USER,
+			Severity: Alerts.AlertSeverity_INFO,
+			Message:  "test message",
+		}
+
+		// Send Event
+		handler.Send(&testParam)
+		resultMessage, resultTopic, err := receiveSentMessage(subscriberSocket)
+
+		assert.Nil(t, err)
+		assert.Equal(t, EventZMQTopic, resultTopic)
+		assert.Equal(t, testParam.GetType(), resultMessage.GetType())
+		assert.Equal(t, testParam.GetSeverity(), resultMessage.GetSeverity())
+		assert.Equal(t, testParam.GetMessage(), resultMessage.GetMessage())
+	})
+
+	// Tear down
+	if shutdownErr := handler.Shutdown(); shutdownErr != nil {
+		fmt.Printf("Failed to stop the goroutine running the ZMQ subscriber %v\n", shutdownErr.Error())
+	}
+	_ = subscriberSocket.Close()
+}
+
+func receiveSentMessage(subscriberSocket *zmq.Socket) (*Alerts.Alert, string, error) {
+	msg, err := subscriberSocket.RecvMessageBytes(0)
+	if err != nil {
+		return nil, "", err
+	}
+
+	resultTopic := string(msg[0])
+	resultMessage := &Alerts.Alert{}
+
+	err = proto.Unmarshal(msg[1], resultMessage)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return resultMessage, resultTopic, nil
+}
+
+func createTestSubscriberSocket(socket string) (*zmq.Socket, error) {
+	pubSocket, err := zmq.NewSocket(zmq.SUB)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = pubSocket.Bind(socket); err != nil {
+		return nil, err
+	}
+
+	if err = pubSocket.SetSubscribe(EventZMQTopic); err != nil {
+		return nil, err
+	}
+
+	return pubSocket, nil
+}
+
+func newTestAlertHandler() *ZmqEventPublisher {
+	return &ZmqEventPublisher{
+		logger:                  mocks.NewMockLogger(),
+		messagePublisherChannel: make(chan ZmqMessage, messageBuffer),
+		zmqPublisherShutdown:    make(chan bool),
+		zmqPublisherStarted:     make(chan int32, 1),
+		socketAddress:           testSocketAddress,
+	}
+}

--- a/services/events/publish_test.go
+++ b/services/events/publish_test.go
@@ -15,7 +15,7 @@ const testSocketAddress = "inproc://testInProcDescriptor"
 
 func TestEventPublisher(t *testing.T) {
 	//Set up
-	handler := newTestAlertHandler()
+	handler := newTestEventHandler()
 	startupErr := handler.Startup()
 	assert.Nil(t, startupErr, "Failed to startup Zmq publisher in background")
 
@@ -81,7 +81,7 @@ func createTestSubscriberSocket(socket string) (*zmq.Socket, error) {
 	return pubSocket, nil
 }
 
-func newTestAlertHandler() *ZmqEventPublisher {
+func newTestEventHandler() *ZmqEventPublisher {
 	return &ZmqEventPublisher{
 		logger:                  mocks.NewMockLogger(),
 		messagePublisherChannel: make(chan ZmqMessage, messageBuffer),

--- a/services/events/publish_test.go
+++ b/services/events/publish_test.go
@@ -3,16 +3,25 @@ package events
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	zmq "github.com/pebbe/zmq4"
 	"github.com/stretchr/testify/assert"
+	"github.com/untangle/golang-shared/structs/protocolbuffers/Alerts"
 	"github.com/untangle/golang-shared/testing/mocks"
+
+	"google.golang.org/protobuf/proto"
 )
 
 const testSocketAddress = "inproc://testInProcDescriptor"
+const testSocketAddress1 = "inproc://testInProcDescriptor1"
 
+// TestEventPublisher tests the functionality of the ZmqEventPublisher.
+// It sets up a test event handler, creates a test subscriber socket, and tests
+// sending both ZmqMessage and Event messages.
+// It verifies that the messages are received correctly by the subscriber socket.
 func TestEventPublisher(t *testing.T) {
-	//Set up
+	// Set up event Publisher
 	handler := newTestEventHandler()
 	startupErr := handler.Startup()
 	assert.Nil(t, startupErr, "Failed to startup Zmq publisher in background")
@@ -21,19 +30,39 @@ func TestEventPublisher(t *testing.T) {
 	assert.Nil(t, err)
 	defer subscriberSocket.Close() // Close socket in case of error
 
+	// test ZmqMessage send functionality
 	t.Run("send message", func(t *testing.T) {
-		testParam := ZmqMessage{
+		testZmqMessageParam := ZmqMessage{
 			Topic:   AlertZMQTopic,
 			Message: []byte(`{"message": "test message"}`),
 		}
 
-		// Send Event
-		handler.Send(&testParam)
-		resultMessage, resultTopic, err := receiveSentMessage(subscriberSocket)
+		// Send ZmqMessage
+		handler.SendZmqMessage(&testZmqMessageParam)
+		resultMessage, resultTopic, err := receiveSentZmqMessage(subscriberSocket)
 
 		assert.Nil(t, err)
 		assert.Equal(t, AlertZMQTopic, resultTopic)
-		assert.Equal(t, testParam.Message, resultMessage)
+		assert.Equal(t, testZmqMessageParam.Message, resultMessage)
+	})
+
+	// test Event send functionality
+	t.Run("send message", func(t *testing.T) {
+		testAlertParam := Alerts.Alert{
+			Type:     Alerts.AlertType_USER,
+			Severity: Alerts.AlertSeverity_INFO,
+			Message:  "test message",
+		}
+
+		// Send Event
+		handler.Send(&testAlertParam)
+		resultMessage, resultTopic, err := receiveSentEventMessage(subscriberSocket)
+
+		assert.Nil(t, err)
+		assert.Equal(t, AlertZMQTopic, resultTopic)
+		assert.Equal(t, testAlertParam.GetType(), resultMessage.GetType())
+		assert.Equal(t, testAlertParam.GetSeverity(), resultMessage.GetSeverity())
+		assert.Equal(t, testAlertParam.GetMessage(), resultMessage.GetMessage())
 	})
 
 	// Tear down
@@ -42,7 +71,53 @@ func TestEventPublisher(t *testing.T) {
 	}
 }
 
-func receiveSentMessage(subscriberSocket *zmq.Socket) ([]byte, string, error) {
+// TestSubscriberNotReady tests the functionality of the ZmqEventPublisher.
+// It sets up a test event handler, creates a test subscriber socket, and tests
+// sending both ZmqMessage and Event messages when Subscriber is not running.
+func TestSubscriberNotReady(t *testing.T) {
+	// Set up event Publisher
+	handler := newTestEventHandler()
+	startupErr := handler.Startup()
+	assert.Nil(t, startupErr, "Failed to startup Zmq publisher in background")
+
+	subscriberSocket, err := createTestSubscriberSocket(testSocketAddress1)
+	assert.Nil(t, err)
+	defer subscriberSocket.Close() // Close socket in case of error
+
+	// test ZmqMessage send functionality
+	t.Run("send message", func(t *testing.T) {
+		testZmqMessageParam := ZmqMessage{
+			Topic:   AlertZMQTopic,
+			Message: []byte(`{"message": "test message"}`),
+		}
+
+		// Send ZmqMessage
+		handler.SendZmqMessage(&testZmqMessageParam)
+		time.Sleep(time.Second * 1)
+	})
+
+	// test Event send functionality
+	t.Run("send message", func(t *testing.T) {
+		testAlertParam := Alerts.Alert{
+			Type:     Alerts.AlertType_USER,
+			Severity: Alerts.AlertSeverity_INFO,
+			Message:  "test message",
+		}
+
+		// Send Event
+		handler.Send(&testAlertParam)
+		time.Sleep(time.Second * 1)
+	})
+
+	// Tear down
+	if shutdownErr := handler.Shutdown(); shutdownErr != nil {
+		fmt.Printf("Failed to stop the goroutine running the ZMQ subscriber %v\n", shutdownErr.Error())
+	}
+}
+
+// receiveSentZmqMessage receives a sent ZMQ message from the subscriber socket.
+// It returns the message, topic, and any error that occurred during reception.
+func receiveSentZmqMessage(subscriberSocket *zmq.Socket) ([]byte, string, error) {
 	msg, err := subscriberSocket.RecvMessageBytes(0)
 	if err != nil {
 		return []byte(""), "", err
@@ -54,6 +129,28 @@ func receiveSentMessage(subscriberSocket *zmq.Socket) ([]byte, string, error) {
 	return resultMessage, resultTopic, nil
 }
 
+// receiveSentEventMessage receives a sent Event message from the subscriber socket.
+// It returns the Event message, topic, and any error that occurred during reception.
+// The Event message is unmarshaled from the received bytes using protocol buffers.
+func receiveSentEventMessage(subscriberSocket *zmq.Socket) (*Alerts.Alert, string, error) {
+	msg, err := subscriberSocket.RecvMessageBytes(0)
+	if err != nil {
+		return nil, "", err
+	}
+
+	resultTopic := string(msg[0])
+	resultMessage := &Alerts.Alert{}
+
+	err = proto.Unmarshal(msg[1], resultMessage)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return resultMessage, resultTopic, nil
+}
+
+// createTestSubscriberSocket creates a new subscriber socket for testing.
+// It binds the socket to the specified address and sets the subscription to the AlertZMQTopic.
 func createTestSubscriberSocket(socket string) (*zmq.Socket, error) {
 	subSocket, err := zmq.NewSocket(zmq.SUB)
 	if err != nil {
@@ -71,6 +168,8 @@ func createTestSubscriberSocket(socket string) (*zmq.Socket, error) {
 	return subSocket, nil
 }
 
+// newTestEventHandler creates a new test event handler for testing.
+// It returns a new ZmqEventPublisher instance with a mock logger and test socket address.
 func newTestEventHandler() *ZmqEventPublisher {
 	return &ZmqEventPublisher{
 		logger:                  mocks.NewMockLogger(),

--- a/services/events/publish_test.go
+++ b/services/events/publish_test.go
@@ -23,7 +23,7 @@ func TestEventPublisher(t *testing.T) {
 
 	t.Run("send message", func(t *testing.T) {
 		testParam := ZmqMessage{
-			Topic:   ZMQTopicRestdEvents,
+			Topic:   AlertZMQTopic,
 			Message: []byte(`{"type": "user", "severity": "info", "message": "test message"}`),
 		}
 
@@ -32,7 +32,7 @@ func TestEventPublisher(t *testing.T) {
 		resultMessage, resultTopic, err := receiveSentMessage(subscriberSocket)
 
 		assert.Nil(t, err)
-		assert.Equal(t, ZMQTopicRestdEvents, resultTopic)
+		assert.Equal(t, AlertZMQTopic, resultTopic)
 		assert.Equal(t, testParam.Topic, resultMessage.Topic)
 		assert.Equal(t, testParam.Message, resultMessage.Message)
 	})
@@ -45,12 +45,13 @@ func TestEventPublisher(t *testing.T) {
 }
 
 func receiveSentMessage(subscriberSocket *zmq.Socket) (*ZmqMessage, string, error) {
-	// fmt.Printf("Inside receiveSentMessage\n")
+	fmt.Printf("Inside receiveSentMessage\n")
 	msg, err := subscriberSocket.RecvMessageBytes(0)
 	if err != nil {
+		fmt.Printf("got error: %v\n", err)
 		return nil, "", err
 	}
-	// fmt.Printf("message received: %v\n", msg)
+	fmt.Printf("message received: %v\n", msg)
 
 	resultTopic := string(msg[0])
 	resultMessage := &ZmqMessage{}
@@ -75,7 +76,7 @@ func createTestSubscriberSocket(socket string) (*zmq.Socket, error) {
 		return nil, err
 	}
 
-	if err = subSocket.SetSubscribe(ZMQTopicRestdEvents); err != nil {
+	if err = subSocket.SetSubscribe(AlertZMQTopic); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Changes:
created an event publisher to share events between packetd and reportd, restd and reportd
Events would be communicated in the below flow
  1. packetd → reportd
  2. restd → reportd