### PR TITLE
EFW-442 Fix getPlatformFileName() to just handle OpenWRT and native

### DIFF
--- a/services/settings/filesystem.go
+++ b/services/settings/filesystem.go
@@ -15,7 +15,7 @@ type FilenameLocator struct {
 
 const (
 	// Present of file indicates we are in native mode
-	nativeEOSIndicatorFile = "/etc/EfwNativeEos"
+	nativeEOSIndicatorFile = "/etc/efw-version"
 
 	// Standard prefix for natic EOS
 	nativeEOSPrefix = "/mnt/flash/mfw-settings/"

--- a/services/settings/filesystem.go
+++ b/services/settings/filesystem.go
@@ -17,7 +17,7 @@ const (
 	// Present of file indicates we are in native mode
 	nativeEOSIndicatorFile = "/etc/efw-version"
 
-	// Standard prefix for natic EOS
+	// Standard prefix for native EOS
 	nativeEOSPrefix = "/mnt/flash/mfw-settings/"
 
 	// Standard prefix for OpenWRT
@@ -60,7 +60,7 @@ func FileExists(fname string) bool {
 // it assumes that called uses default to OpenWRT platform. Only paths in mappings or paths which
 // starts with /etc/config are translated.
 func (f *FilenameLocator) getPlatformFileName(filename string) (string, error) { // Check if we are in native mode, most likely since there is only native and OpenWRT mode
-	if f.fileExists(nativeEOSIndicatorFile) { // In EOS mode, try maping
+	if f.fileExists(nativeEOSIndicatorFile) { // In EOS mode, try mapping
 		if nativePath, exists := openWRTFileToNativeEOS[filename]; exists {
 			if !f.fileExists(nativePath) {
 				return nativePath, &NoFileAtPath{name: nativePath}
@@ -77,7 +77,7 @@ func (f *FilenameLocator) getPlatformFileName(filename string) (string, error) {
 			}
 		}
 	}
-	// On OpenWRT, no translation needed
+	// On OpenWRT or no translation needed
 	if !f.fileExists(filename) {
 		return filename, &NoFileAtPath{name: filename}
 	}

--- a/services/settings/filesystem_test.go
+++ b/services/settings/filesystem_test.go
@@ -25,45 +25,52 @@ func TestFilenameLocator(t *testing.T) {
 		fileExists: existFake.doesExist}
 	tests := []struct {
 		filename     string
-		existResults []bool // Indicates (file initially exists, In kernel/openwrt mode , new file exists)
+		existResults []bool // Indicates (input file exists, OnEOSPlatform, File exists after translation)
 		returnValue  string
 		returnErr    error
 	}{
 		{
+			// File exists, should get the same back.
 			filename:     "/etc/config/settings.json",
-			existResults: []bool{false, false, false, true},
-			returnValue:  "/mnt/flash/mfw-settings/settings.json",
-		},
-		{
-			filename:     "/usr/share/geoip",
-			existResults: []bool{false, false, false, true},
-			returnValue:  "/mfw/usr/share/geoip",
-		},
-		{
-			filename:     "/etc/config/appstate.json",
-			existResults: []bool{false, false, false, true},
-			returnValue:  "/mnt/flash/mfw-settings/appstate.json",
-		},
-		{
-			filename:     "/etc/config/settings.json",
-			existResults: []bool{true, true, true},
+			existResults: []bool{true},
 			returnValue:  "/etc/config/settings.json",
 		},
 		{
-			filename:     "/etc/config/appstate.json",
-			existResults: []bool{true, true, true},
-			returnValue:  "/etc/config/appstate.json",
+			// In OpenWRT mode, no translation since the defaults are openwrt paths.
+			// returns with no error
+			filename:     "/usr/share/geoip",
+			existResults: []bool{false, false, true},
+			returnValue:  "/usr/share/geoip",
 		},
 		{
+			// In Native mode, do translation
 			filename:     "/etc/config/appstate.json",
-			existResults: []bool{false, false, false, false},
+			existResults: []bool{false, true, true},
 			returnValue:  "/mnt/flash/mfw-settings/appstate.json",
-			returnErr:    fmt.Errorf("no file at path: /mnt/flash/mfw-settings/appstate.json"),
 		},
 		{
-			filename:     "/etc/config/categories.json",
+			// In Native mode, do translation, file is not there so return error
+			filename:     "/etc/config/settings.json",
+			existResults: []bool{false, true, false},
+			returnValue:  "/mnt/flash/mfw-settings/settings.json",
+			returnErr:    fmt.Errorf("no file at path: /mnt/flash/mfw-settings/settings.json"),
+		},
+		{
+			// In Native mode, do translation, file exists, not error
+			filename:     "/etc/config/appstate.json",
+			existResults: []bool{false, true, true},
+			returnValue:  "/mnt/flash/mfw-settings/appstate.json",
+		},
+		{ // Native mode, no translation, file exists
+			filename:     "/usr/share/bctid/categories.json",
 			existResults: []bool{false, false, true},
 			returnValue:  "/usr/share/bctid/categories.json",
+		},
+		{ // Native mode, translate. New file not there, return error
+			filename:     "/etc/config/categories.json",
+			existResults: []bool{false, true, false},
+			returnValue:  "/usr/share/bctid/categories.json",
+			returnErr:    fmt.Errorf("no file at path: /usr/share/bctid/categories.json"),
 		},
 	}
 

--- a/services/settings/filesystem_test.go
+++ b/services/settings/filesystem_test.go
@@ -66,6 +66,18 @@ func TestFilenameLocator(t *testing.T) {
 			existResults: []bool{false, false, true},
 			returnValue:  "/usr/share/bctid/categories.json",
 		},
+		{ // Native mode, New file not there, return same thing
+			filename:     "/tmp/captivesocket",
+			existResults: []bool{false, true, false},
+			returnValue:  "/tmp/captivesocket",
+			returnErr:    fmt.Errorf("no file at path: /tmp/captivesocket"),
+		},
+		{ // OpenWRT mode, translate. New file not there, return same thing
+			filename:     "/tmp/captivesocket",
+			existResults: []bool{false, false, false},
+			returnValue:  "/tmp/captivesocket",
+			returnErr:    fmt.Errorf("no file at path: /tmp/captivesocket"),
+		},
 		{ // Native mode, translate. New file not there, return error
 			filename:     "/etc/config/categories.json",
 			existResults: []bool{false, true, false},


### PR DESCRIPTION
- Simplified the getPlatformFileName() to just handle OpenWRT and native mode. 
- Updated tests to reflect no more hybrid.