### PR TITLE
EFW-463_schedule_travis-skip

### DIFF
--- a/barney.context
+++ b/barney.context
@@ -13,6 +13,9 @@
 		"barney.ci/byob": {
 			"commit": "c3a49dcd93bd98b45a3450d88bd5416844d506f8"
 		},
+		"barney.ci/debian": {
+			"commit": "eb84e7903cfd32bffe2b0ab068bc6c87aa810885"
+		},
 		"barney.ci/docker": {
 			"commit": "dcb450791c55d7ce31d648fecd7ee75ffbe92815"
 		},

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,12 +1,15 @@
 {
     "automergeSchedule": ["at any time"],
+    commitMessage: "{{{commitMessagePrefix}}} {{{commitMessageAction}}} {{{commitMessageTopic}}} {{{commitMessageExtra}}} {{{commitMessageSuffix}}} [skip travis]",
 
     packageRules: [
         {
             // bar stands for Barney Auto Roller - more info: go/barney-glossary
             "matchDatasources": ["custom.bar"],
             "matchPackageNames": ["code.arista.io/infra/barney/barnzilla-repos"],
-            "automergeSchedule": ["at any time"]
+            "automergeSchedule": ["* 0-3 * * *"],
+            "timezone": "Etc/UTC",
+            commitMessage: "{{{commitMessagePrefix}}} {{{commitMessageAction}}} {{{commitMessageTopic}}} {{{commitMessageExtra}}} {{{commitMessageSuffix}}} [skip travis]",
         }
     ]
 }


### PR DESCRIPTION
https://awakesecurity.atlassian.net/browse/EFW-463

I'm skipping Travis-ci for BAR updates and changing schedule for auto merge for barnzilla-repos
I on purpose, add the changes to repos under Untangle org that has no Travis checks in case we want to add them later