### PR TITLE
Make Platform available outside of golang-shared

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -124,15 +124,15 @@ func DecodeAttribute(value string) (string, error) {
 	return string(decodedBytes), nil
 }
 
-type platform string
+type Platform string
 
 const (
-	EOS     platform = "MFW_EOS"
-	OpenWRT platform = "OPENWRT"
+	EOS     Platform = "MFW_EOS"
+	OpenWRT Platform = "OPENWRT"
 )
 
 // GetPlatform determines the platform of the system
-func GetPlatform() platform {
+func GetPlatform() Platform {
 	if _, err := os.Stat("/etc/efw-version"); err == nil {
 		// For eos-native return mfwEOS
 		return EOS


### PR DESCRIPTION
I need Platform being available outside of golang-shared to address comment https://github.com/untangle/restd/pull/1362#discussion_r1996067887