### PR TITLE
MFW-6452: Adding Application Description to App Control

### DIFF
--- a/services/dpi/dpi_loader_test.go
+++ b/services/dpi/dpi_loader_test.go
@@ -75,6 +75,7 @@ func (suite *TestLoadDpiJson) TestLoadConfig_Valid() {
 	app, found := applications[3]
 	suite.True(found, "Application with ID 3 should be found")
 	suite.Equal("zoom", app.Name)
+	suite.Equal("Zoom Video Conferencing", app.Description)
 	suite.Equal("Instant Messaging", app.Family)
 	expectedTags := []string{"aetls", "audio_chat", "cloud_services", "enterprise", "im_mc", "video_chat", "voip"}
 	suite.ElementsMatch(expectedTags, app.Tag)

--- a/services/dpi/testdata/DpiDefaultConfig.json
+++ b/services/dpi/testdata/DpiDefaultConfig.json
@@ -22,6 +22,7 @@
     },
     "applications": {
         "vxlan": {
+            "description": "vxlan is a network virtualization technology",
             "family": "Network service",
             "tag": [
                 "basic",
@@ -36,6 +37,7 @@
             "vendor-service-attributes": {}
         },
         "ymsg_transfer": {
+            "description": "This protocol is used for file transfers",
             "family": "File Transfer",
             "tag": [
                 "file_transfer",
@@ -65,6 +67,7 @@
             }
         },
         "zoom": {
+            "description": "Zoom Video Conferencing",
             "family": "Instant Messaging",
             "tag": [
                 "aetls",


### PR DESCRIPTION
https://awakesecurity.atlassian.net/browse/MFW-6452


Passing Unit Tests:
![Screenshot 2025-04-02 at 12 45 07](https://github.com/user-attachments/assets/f1db95b3-0f74-4347-91f9-c984adff17b8)
![Screenshot 2025-04-02 at 12 46 09](https://github.com/user-attachments/assets/899ca385-5439-4730-ae20-aa171e228f4c)
<img width="1467" alt="Screenshot 2025-04-02 at 13 19 19" src="https://github.com/user-attachments/assets/f3614326-912a-41de-84b4-baa4cf419fb3" />


QosmosInfo map is now passed by reference, to avoid copying large amounts of data (primarily due to `description` field). Unit tests have passed, and HandleNfqueue works as expected after the changes:

![Screenshot 2025-04-02 at 13 36 27](https://github.com/user-attachments/assets/aa1533c3-7a69-4561-bb30-7b89917a91c0)

