### PR TITLE
Fix a bug in filesystem.go

### DIFF
--- a/services/filesystem/filesystem.go
+++ b/services/filesystem/filesystem.go
@@ -99,7 +99,14 @@ func (f *PlatformAwareFileSystem) GetPathOnPlatform(p string) (string, error) {
 
 	nativePath := p
 	if strings.Contains(p, platform.OpenWrt.SettingsDirPath) {
-		nativePath = filepath.Join(f.platform.SettingsDirPath, p[strings.LastIndex(p, "/")+1:])
+		parts := strings.SplitAfterN(p, platform.OpenWrt.SettingsDirPath, 2)
+		nativePath := filepath.Join(f.platform.SettingsDirPath, strings.TrimPrefix(parts[1], "/"))
+
+		if !f.FileExists(nativePath) {
+			return nativePath, &NoFileAtPath{name: nativePath}
+		} else {
+			return nativePath, nil
+		}
 	}
 
 	if !f.FileExists(nativePath) {

--- a/services/filesystem/filesystem_test.go
+++ b/services/filesystem/filesystem_test.go
@@ -58,6 +58,16 @@ func TestOpen(t *testing.T) {
 			expectedData: "setting value",
 		},
 		{
+			name:         "Open file on EOS - settings path with subdirectory exists",
+			platformType: platform.EOS,
+			files: fstest.MapFS{
+				"mnt/flash/mfw-settings/sub/dir/file.txt": {Data: []byte("deep file")},
+			},
+			fileName:     "/etc/config/sub/dir/file.txt",
+			expectedErr:  false,
+			expectedData: "deep file",
+		},
+		{
 			name:         "Open file on EOS - settings path does not exist",
 			platformType: platform.EOS,
 			files:        fstest.MapFS{},
@@ -173,6 +183,16 @@ func TestStat(t *testing.T) {
 			fileName:     "/etc/config/categories.json",
 			expectedErr:  true,
 			expectedSize: 0,
+		},
+		{
+			name:         "Stat file on EOS - settings path with subdirectory exists",
+			platformType: platform.EOS,
+			files: fstest.MapFS{
+				"mnt/flash/mfw-settings/sub/dir/file.txt": {Data: []byte("deep file")},
+			},
+			fileName:     "/etc/config/sub/dir/file.txt",
+			expectedErr:  false,
+			expectedSize: 9,
 		},
 		{
 			name:         "Stat non-existent file",


### PR DESCRIPTION
Paths with subdirectories under them are not correctly modifed,

`/etc/config/sub/directory/x.txt` was becoming `/etc/config/x.txt`.