### PR TITLE
Support the pktd-settings-loc-opts packetd branch by adding some filesystem.go enhancements.

### DIFF
--- a/services/filesystem/filesystem.go
+++ b/services/filesystem/filesystem.go
@@ -127,7 +127,7 @@ func (f *PlatformAwareFileSystem) GetPathOnPlatform(p string) (string, error) {
 
 	if f.prefix != "" {
 		// When joining with a prefix, treat nativePath as relative to the prefix root.
-		return filepath.Join(f.prefix, strings.TrimPrefix(nativePath, "/")), nil
+		nativePath = filepath.Join(f.prefix, strings.TrimPrefix(nativePath, "/"))
 	}
 
 	if !f.FileExists(nativePath) {

--- a/services/filesystem/filesystem.go
+++ b/services/filesystem/filesystem.go
@@ -124,14 +124,14 @@ func (f *PlatformAwareFileSystem) GetPathOnPlatform(p string) (string, error) {
 		nativePath = p
 	}
 
-	if f.prefix != "" {
-		return filepath.Join(f.prefix, nativePath), nil
-	}
-
 	if !f.FileExists(nativePath) {
 		return nativePath, &NoFileAtPath{name: nativePath}
 	}
 
+	if f.prefix != "" {
+		// When joining with a prefix, treat nativePath as relative to the prefix root.
+		return filepath.Join(f.prefix, strings.TrimPrefix(nativePath, "/")), nil
+	}
 
 	return nativePath, nil
 }

--- a/services/filesystem/filesystem.go
+++ b/services/filesystem/filesystem.go
@@ -124,13 +124,15 @@ func (f *PlatformAwareFileSystem) GetPathOnPlatform(p string) (string, error) {
 		nativePath = p
 	}
 
+	if f.prefix != "" {
+		return filepath.Join(f.prefix, nativePath), nil
+	}
+
 	if !f.FileExists(nativePath) {
 		return nativePath, &NoFileAtPath{name: nativePath}
 	}
 
-	if f.prefix != "" {
-		return filepath.Join(f.prefix, nativePath), nil
-	}
+
 	return nativePath, nil
 }
 

--- a/services/filesystem/filesystem.go
+++ b/services/filesystem/filesystem.go
@@ -124,14 +124,16 @@ func (f *PlatformAwareFileSystem) GetPathOnPlatform(p string) (string, error) {
 		nativePath = p
 	}
 
-	if !f.FileExists(nativePath) {
-		return nativePath, &NoFileAtPath{name: nativePath}
-	}
 
 	if f.prefix != "" {
 		// When joining with a prefix, treat nativePath as relative to the prefix root.
 		return filepath.Join(f.prefix, strings.TrimPrefix(nativePath, "/")), nil
 	}
+
+	if !f.FileExists(nativePath) {
+		return nativePath, &NoFileAtPath{name: nativePath}
+	}
+
 
 	return nativePath, nil
 }

--- a/services/filesystem/filesystem_test.go
+++ b/services/filesystem/filesystem_test.go
@@ -274,7 +274,7 @@ func TestGetPathOnPlatform(t *testing.T) {
 			name:         "EOS, mapped file, with prefix, file exists",
 			platformType: platform.EOS,
 			files: fstest.MapFS{
-				"usr/share/bctid/categories.json": {Data: []byte("categories data")},
+				"root/usr/share/bctid/categories.json": {Data: []byte("categories data")},
 			},
 			path:         "/etc/config/categories.json",
 			prefix:       "/root",
@@ -285,7 +285,7 @@ func TestGetPathOnPlatform(t *testing.T) {
 			name:         "EOS, settings file, with prefix, file exists",
 			platformType: platform.EOS,
 			files: fstest.MapFS{
-				"mnt/flash/mfw-settings/settings.json": {Data: []byte("setting value")},
+				"root/mnt/flash/mfw-settings/settings.json": {Data: []byte("setting value")},
 			},
 			path:         "/etc/config/settings.json",
 			prefix:       "/root",

--- a/services/filesystem/filesystem_test.go
+++ b/services/filesystem/filesystem_test.go
@@ -300,7 +300,7 @@ func TestGetPathOnPlatform(t *testing.T) {
 			},
 			path:         "/etc/config/settings.json",
 			prefix:       "",
-			expectedPath: "mnt/flash/mfw-settings/settings.json",
+			expectedPath: "/mnt/flash/mfw-settings/settings.json",
 			expectedErr:  false,
 		},
 		{

--- a/services/filesystem/filesystem_test.go
+++ b/services/filesystem/filesystem_test.go
@@ -238,6 +238,108 @@ func TestStat(t *testing.T) {
 	}
 }
 
+func TestGetPathOnPlatform(t *testing.T) {
+	tests := []struct {
+		name         string
+		platformType platform.HostType
+		files        fstest.MapFS
+		path         string
+		prefix       string
+		expectedPath string
+		expectedErr  bool
+	}{
+		{
+			name:         "OpenWrt, no prefix, file exists",
+			platformType: platform.OpenWrt,
+			files: fstest.MapFS{
+				"file.txt": {Data: []byte("content")},
+			},
+			path:         "file.txt",
+			prefix:       "",
+			expectedPath: "file.txt",
+			expectedErr:  false,
+		},
+		{
+			name:         "OpenWrt, with prefix, file exists",
+			platformType: platform.OpenWrt,
+			files: fstest.MapFS{
+				"file.txt": {Data: []byte("content")},
+			},
+			path:         "file.txt",
+			prefix:       "/tmp",
+			expectedPath: "/tmp/file.txt",
+			expectedErr:  false,
+		},
+		{
+			name:         "EOS, mapped file, with prefix, file exists",
+			platformType: platform.EOS,
+			files: fstest.MapFS{
+				"usr/share/bctid/categories.json": {Data: []byte("categories data")},
+			},
+			path:         "/etc/config/categories.json",
+			prefix:       "/root",
+			expectedPath: "/root/usr/share/bctid/categories.json",
+			expectedErr:  false,
+		},
+		{
+			name:         "EOS, settings file, with prefix, file exists",
+			platformType: platform.EOS,
+			files: fstest.MapFS{
+				"mnt/flash/mfw-settings/settings.json": {Data: []byte("setting value")},
+			},
+			path:         "/etc/config/settings.json",
+			prefix:       "/root",
+			expectedPath: "/root/mnt/flash/mfw-settings/settings.json",
+			expectedErr:  false,
+		},
+		{
+			name:         "EOS, settings file, no prefix, file exists",
+			platformType: platform.EOS,
+			files: fstest.MapFS{
+				"mnt/flash/mfw-settings/settings.json": {Data: []byte("setting value")},
+			},
+			path:         "/etc/config/settings.json",
+			prefix:       "",
+			expectedPath: "mnt/flash/mfw-settings/settings.json",
+			expectedErr:  false,
+		},
+		{
+			name:         "File does not exist, with prefix",
+			platformType: platform.EOS,
+			files:        fstest.MapFS{},
+			path:         "/etc/config/not-there.json",
+			prefix:       "/root",
+			expectedErr:  true,
+		},
+		{
+			name:         "File does not exist, no prefix",
+			platformType: platform.EOS,
+			files:        fstest.MapFS{},
+			path:         "/etc/config/not-there.json",
+			prefix:       "",
+			expectedErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var opts []FileSystemOption
+			if tt.prefix != "" {
+				opts = append(opts, WithPrefix(tt.prefix))
+			}
+			pafs := NewPlatformAwareFileSystem(tt.files, tt.platformType, opts...)
+			path, err := pafs.GetPathOnPlatform(tt.path)
+
+			if tt.expectedErr {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectedPath, path)
+			}
+		})
+	}
+}
+
 func TestSanitizePath(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -265,9 +367,23 @@ func TestSanitizePath(t *testing.T) {
 func TestNewPlatformAwareFileSystem(t *testing.T) {
 	mockFS := fstest.MapFS{}
 	p := platform.OpenWrt
-	pafs := NewPlatformAwareFileSystem(mockFS, p)
 
-	assert.NotNil(t, pafs)
-	assert.Equal(t, mockFS, pafs.FS)
-	assert.Equal(t, p, pafs.platform)
+	t.Run("without options", func(t *testing.T) {
+		pafs := NewPlatformAwareFileSystem(mockFS, p)
+
+		assert.NotNil(t, pafs)
+		assert.Equal(t, mockFS, pafs.FS)
+		assert.Equal(t, p, pafs.platform)
+		assert.Empty(t, pafs.prefix)
+	})
+
+	t.Run("with prefix option", func(t *testing.T) {
+		prefix := "/tmp/root"
+		pafs := NewPlatformAwareFileSystem(mockFS, p, WithPrefix(prefix))
+
+		assert.NotNil(t, pafs)
+		assert.Equal(t, mockFS, pafs.FS)
+		assert.Equal(t, p, pafs.platform)
+		assert.Equal(t, prefix, pafs.prefix)
+	})
 }

--- a/services/settings/settings.go
+++ b/services/settings/settings.go
@@ -24,6 +24,8 @@ import (
 var logger loggerModel.LoggerLevels
 var once sync.Once
 
+const DefaultSettingsFileLocation = "/etc/config/settings.json"
+
 var (
 	settingsFile = "/etc/config/settings.json"
 	defaultsFile = "/etc/config/defaults.json"


### PR DESCRIPTION
Add the explicit ability for the platform aware fileystem to be rooted elsewhere.