### PR TITLE
fix-constructorwrapper-gs: fix-constructorwrapper-gs

### DIFF
--- a/plugins/plugin.go
+++ b/plugins/plugin.go
@@ -34,6 +34,7 @@ type pluginInfo struct {
 	plugin      Plugin
 	metadata    []any
 	constructor PluginConstructor
+	isProvider  bool
 
 	// a function built using the reflect package that will set
 	// the plugin value of this struct. Executed during Startup().
@@ -207,38 +208,15 @@ func (control *PluginControl) RegisterPluginPredicate(predicateFactory PluginPre
 // by the DI container and returns a plugin object. This function will
 // not provide the plugin as a potential dependency for other plugins.
 func (control *PluginControl) RegisterPlugin(constructor PluginConstructor, metadata ...any) {
-	constructorType := reflect.TypeOf(constructor)
-	constructorVal := reflect.ValueOf(constructor)
-	inputs := []reflect.Type{}
-	for i := 0; i < constructorType.NumIn(); i++ {
-		inputs = append(inputs, constructorType.In(i))
-	}
-
-	if control.wrapper != nil && control.wrapper.Matches(constructor, metadata...) {
-		constructorVal = makeWrapperConstructor(control.wrapper, constructor, metadata)
-	}
-
 	pluginInfo := &pluginInfo{
 		constructor: constructor,
 		metadata:    metadata,
+		isProvider:  false,
 
 		// to be set later by our constructed function, if
 		// needed.
 		plugin: nil,
 	}
-
-	// create a func at runtime that we can invoke that calls the
-	// constructor and appends the return value to the list of plugins.
-	saverFunc := reflect.MakeFunc(
-		reflect.FuncOf(inputs, []reflect.Type{}, false),
-		func(vals []reflect.Value) []reflect.Value {
-			output := constructorVal.Call(vals)
-			plugin := output[0].Interface()
-			pluginIntf := plugin.(Plugin)
-			pluginInfo.plugin = pluginIntf
-			return []reflect.Value{}
-		})
-	pluginInfo.saverFunc = saverFunc.Interface()
 	control.pluginInfo = append(control.pluginInfo, pluginInfo)
 }
 
@@ -257,44 +235,67 @@ func (control *PluginControl) GetRegisteredPluginCount() int {
 // plugins may require it. It is not instantiated until the Startup()
 // method is called.
 func (control *PluginControl) RegisterAndProvidePlugin(constructor PluginConstructor, metadata ...any) {
-	constructorType := reflect.TypeOf(constructor)
-	outputType := constructorType.Out(0)
 	pluginInfo := &pluginInfo{
 		plugin:      nil,
 		metadata:    metadata,
 		constructor: constructor,
 		saverFunc:   nil,
+		isProvider:  true,
 	}
 	control.pluginInfo = append(control.pluginInfo, pluginInfo)
-	// create a func at runtime that we can invoke that requires the
-	// plugin to ensure it gets instantiated, and also appends it to
-	// the list of registered plugins.  This is different from in
-	// RegisterPlugin because here we require the plugin as an input,
-	// which in turn also requires the plugin to have been provided as
-	// an output via Provide() (see below).
-	//
-	// Although similar to RegisterPlugin(), this is fundamentally
-	// different and can't be merged with that implementation as that
-	// implementation must allow multiple registrations of identical
-	// types, since they may have different constructor functions.
-	saverFunc := reflect.MakeFunc(
-		reflect.FuncOf([]reflect.Type{outputType}, []reflect.Type{}, false),
-		func(vals []reflect.Value) []reflect.Value {
-			plugin := vals[0].Interface()
-			pluginIntf := plugin.(Plugin)
-			pluginInfo.plugin = pluginIntf
-			return []reflect.Value{}
-		})
-	pluginInfo.saverFunc = saverFunc.Interface()
-	if err := control.Provide(constructor); err != nil {
-		panic(fmt.Sprintf(
-			"couldn't register plugin constructor as a provider: %v, err: %s", constructor, err))
-	}
 }
 
 // UnregisterPlugin removes a plugin from the list of plugins
 func (control *PluginControl) UnregisterPluginByIndex(indx int) {
 	control.pluginInfo = append(control.pluginInfo[:indx], control.pluginInfo[indx+1:]...)
+}
+
+func (control *PluginControl) preparePlugins() {
+	for _, pluginInfo := range control.pluginInfo {
+		constructor := pluginInfo.constructor
+		constructorVal := reflect.ValueOf(constructor)
+
+		if control.wrapper != nil && control.wrapper.Matches(constructor, pluginInfo.metadata...) {
+			constructorVal = makeWrapperConstructor(control.wrapper, constructor, pluginInfo.metadata)
+		}
+
+		actualConstructor := constructorVal.Interface()
+
+		if pluginInfo.isProvider {
+			constructorType := reflect.TypeOf(actualConstructor)
+			outputType := constructorType.Out(0)
+
+			saverFunc := reflect.MakeFunc(
+				reflect.FuncOf([]reflect.Type{outputType}, []reflect.Type{}, false),
+				func(vals []reflect.Value) []reflect.Value {
+					plugin := vals[0].Interface()
+					pluginIntf := plugin.(Plugin)
+					pluginInfo.plugin = pluginIntf
+					return []reflect.Value{}
+				})
+			pluginInfo.saverFunc = saverFunc.Interface()
+			if err := control.Provide(actualConstructor); err != nil {
+				panic(fmt.Sprintf(
+					"couldn't register plugin constructor as a provider: %v, err: %s", constructor, err))
+			}
+		} else {
+			constructorType := reflect.TypeOf(actualConstructor)
+			inputs := []reflect.Type{}
+			for i := 0; i < constructorType.NumIn(); i++ {
+				inputs = append(inputs, constructorType.In(i))
+			}
+			saverFunc := reflect.MakeFunc(
+				reflect.FuncOf(inputs, []reflect.Type{}, false),
+				func(vals []reflect.Value) []reflect.Value {
+					output := constructorVal.Call(vals)
+					plugin := output[0].Interface()
+					pluginIntf := plugin.(Plugin)
+					pluginInfo.plugin = pluginIntf
+					return []reflect.Value{}
+				})
+			pluginInfo.saverFunc = saverFunc.Interface()
+		}
+	}
 }
 
 // filterPlugins filters the plugin list using the predicates.
@@ -336,6 +337,7 @@ PluginLoop:
 // registered with the backend so they will receive these events.
 func (control *PluginControl) Startup() {
 	control.filterPlugins()
+	control.preparePlugins()
 	for _, pluginInf := range control.pluginInfo {
 		if err := control.Invoke(pluginInf.saverFunc); err != nil {
 			err = fmt.Errorf("couldn't instantiate plugin with constructor %T: %w", pluginInf.constructor, err)

--- a/plugins/plugin.go
+++ b/plugins/plugin.go
@@ -255,6 +255,7 @@ func (control *PluginControl) preparePlugins() {
 		constructor := pluginInfo.constructor
 		constructorVal := reflect.ValueOf(constructor)
 
+		// first, see if we need to wrap the constructor.
 		if control.wrapper != nil && control.wrapper.Matches(constructor, pluginInfo.metadata...) {
 			constructorVal = makeWrapperConstructor(control.wrapper, constructor, pluginInfo.metadata)
 		}

--- a/plugins/wrapper_test.go
+++ b/plugins/wrapper_test.go
@@ -9,6 +9,7 @@ import (
 
 type wrapperTest struct {
 	WrapperHelper
+	matches bool
 }
 
 // decorator is a test double for a plugin that 'decorates' another
@@ -72,7 +73,7 @@ func (d *decorator) NotifyNewPolicy(pol string, fakeSettings map[string]any) {
 }
 
 func newWrapperTest(d *decorator) *wrapperTest {
-	w := &wrapperTest{}
+	w := &wrapperTest{matches: true}
 	w.SetConstructorReturn(
 		ConstructorWrapperPluginFactory(func(gen PluginGeneratorCallback, _ ...any) Plugin {
 			d.newPluginCallback = gen
@@ -84,7 +85,7 @@ func newWrapperTest(d *decorator) *wrapperTest {
 func (w *wrapperTest) Matches(val PluginConstructor, metadata ...any) bool {
 	// ideally this should examine 'val' to decide if it's the
 	// type of plugin we want to wrap.
-	return true
+	return w.matches
 }
 
 func NewMockPlugin(config *Config) *MockPlugin {
@@ -94,7 +95,109 @@ func NewMockPlugin(config *Config) *MockPlugin {
 	return m
 }
 
-func TestWrapper(t *testing.T) {
+func TestWrapperRegistrationOrder(t *testing.T) {
+	testLogic := func(t *testing.T, register func(controller *PluginControl, decorator *decorator)) {
+		controller := NewPluginControl()
+		decorator := &decorator{decorated: map[string]SettingsInjectablePlugin{}}
+
+		register(controller, decorator)
+
+		err := controller.Provide(func() *Config {
+			return &Config{}
+		})
+		assert.NoError(t, err)
+
+		controller.Startup()
+
+		// NotifyNewPolicy will create a new instance of the wrapped
+		// plugin, and inject the settings into it.
+		decorator.NotifyNewPolicy("policy1", map[string]any{
+			"name": "policy1settings",
+			"id":   "myIDpolicy1plugin",
+		})
+		decorator.NotifyNewPolicy("policy2", map[string]any{
+			"name": "policy2settings",
+			"id":   "myIDpolicy2plugin",
+		})
+		assert.NotNil(t, decorator.decorated["policy1"])
+		assert.NotNil(t, decorator.decorated["policy2"])
+
+		assert.Equal(t, decorator.decorated["policy1"].(*MockPlugin).config.Name,
+			"policy1settings")
+		assert.Equal(t,
+			decorator.decorated["policy1"].(*MockPlugin).config.ID,
+			"myIDpolicy1plugin")
+
+		assert.Equal(t, decorator.decorated["policy2"].(*MockPlugin).config.Name,
+			"policy2settings")
+		assert.Equal(t, decorator.decorated["policy2"].(*MockPlugin).config.ID,
+			"myIDpolicy2plugin")
+
+		decorator.NotifyNewPolicy("policy2", map[string]any{
+			"name": "policy2settingsSecondTime",
+			"id":   "myIDpolicy2plugin",
+		})
+		assert.Equal(t, decorator.decorated["policy2"].(*MockPlugin).config.Name,
+			"policy2settingsSecondTime")
+	}
+
+	t.Run("WrapperRegisteredFirst", func(t *testing.T) {
+		testLogic(t, func(controller *PluginControl, decorator *decorator) {
+			controller.RegisterConstructorWrapper(func() ConstructorWrapper {
+				return newWrapperTest(decorator)
+			})
+			controller.RegisterPlugin(NewMockPlugin)
+		})
+	})
+
+	t.Run("PluginRegisteredFirst", func(t *testing.T) {
+		testLogic(t, func(controller *PluginControl, decorator *decorator) {
+			controller.RegisterPlugin(NewMockPlugin)
+			controller.RegisterConstructorWrapper(func() ConstructorWrapper {
+				return newWrapperTest(decorator)
+			})
+		})
+	})
+}
+
+func TestWrapperNoMatch(t *testing.T) {
+	controller := NewPluginControl()
+	decorator := &decorator{decorated: map[string]SettingsInjectablePlugin{}}
+	wrapper := newWrapperTest(decorator)
+	wrapper.matches = false
+
+	controller.RegisterConstructorWrapper(func() ConstructorWrapper {
+		return wrapper
+	})
+	err := controller.Provide(func() *Config {
+		return &Config{Name: "unwrapped"}
+	})
+	assert.NoError(t, err)
+
+	var createdPlugin *MockPlugin
+	controller.RegisterPlugin(func(cfg *Config) *MockPlugin {
+		p := NewMockPlugin(cfg)
+		createdPlugin = p
+		return p
+	})
+	controller.Startup()
+
+	// wrapper was not used, so decorator is untouched
+	assert.Nil(t, decorator.newPluginCallback)
+
+	// original plugin was created
+	assert.NotNil(t, createdPlugin)
+	assert.Equal(t, "unwrapped", createdPlugin.config.Name)
+
+	// ensure it was started
+	createdPlugin.AssertCalled(t, "Startup")
+
+	// and it's in the plugin list
+	assert.Len(t, controller.pluginInfo, 1)
+	assert.Same(t, createdPlugin, controller.pluginInfo[0].plugin)
+}
+
+func TestWrapperWithProvidedPlugin(t *testing.T) {
 	controller := NewPluginControl()
 	decorator := &decorator{decorated: map[string]SettingsInjectablePlugin{}}
 	controller.RegisterConstructorWrapper(func() ConstructorWrapper {
@@ -103,41 +206,41 @@ func TestWrapper(t *testing.T) {
 	err := controller.Provide(func() *Config {
 		return &Config{}
 	})
-	if err != nil {
-		logger.Warn("Failed to provide return value: %v\n", err.Error())
-	}
+	assert.NoError(t, err)
 
-	controller.RegisterPlugin(NewMockPlugin)
+	controller.RegisterAndProvidePlugin(NewMockPlugin)
 	controller.Startup()
 
-	// NotifyNewPolicy will create a new instance of the wrapped
-	// plugin, and inject the settings into it.
+	// The decorator should be the only plugin in the list.
+	assert.Len(t, controller.pluginInfo, 1)
+	assert.Same(t, decorator, controller.pluginInfo[0].plugin)
+
+	// Assert wrapper was used
+	assert.NotNil(t, decorator.newPluginCallback)
+	// Now check if decoration works
 	decorator.NotifyNewPolicy("policy1", map[string]any{
 		"name": "policy1settings",
 		"id":   "myIDpolicy1plugin",
 	})
-	decorator.NotifyNewPolicy("policy2", map[string]any{
-		"name": "policy2settings",
-		"id":   "myIDpolicy2plugin",
-	})
 	assert.NotNil(t, decorator.decorated["policy1"])
-	assert.NotNil(t, decorator.decorated["policy2"])
+	assert.Equal(t, "policy1settings", decorator.decorated["policy1"].(*MockPlugin).config.Name)
+}
 
-	assert.Equal(t, decorator.decorated["policy1"].(*MockPlugin).config.Name,
-		"policy1settings")
-	assert.Equal(t,
-		decorator.decorated["policy1"].(*MockPlugin).config.ID,
-		"myIDpolicy1plugin")
-
-	assert.Equal(t, decorator.decorated["policy2"].(*MockPlugin).config.Name,
-		"policy2settings")
-	assert.Equal(t, decorator.decorated["policy2"].(*MockPlugin).config.ID,
-		"myIDpolicy2plugin")
-
-	decorator.NotifyNewPolicy("policy2", map[string]any{
-		"name": "policy2settingsSecondTime",
-		"id":   "myIDpolicy2plugin",
+func TestWrapperFactoryReturnsWrongType(t *testing.T) {
+	controller := NewPluginControl()
+	assert.PanicsWithValue(t, "from RegisterConstructorWrapper: Unable to convert provided wrapper to PluginWrapper", func() {
+		controller.RegisterConstructorWrapper(func() any {
+			return struct{}{}
+		})
 	})
-	assert.Equal(t, decorator.decorated["policy2"].(*MockPlugin).config.Name,
-		"policy2settingsSecondTime")
+}
+
+func TestWrapperFactoryWithMissingDependency(t *testing.T) {
+	controller := NewPluginControl()
+	type SomeDependency struct{}
+	assert.Panics(t, func() {
+		controller.RegisterConstructorWrapper(func(*SomeDependency) ConstructorWrapper {
+			return newWrapperTest(nil)
+		})
+	})
 }

--- a/plugins/wrapper_test.go
+++ b/plugins/wrapper_test.go
@@ -232,6 +232,7 @@ func TestWrapperFactoryReturnsWrongType(t *testing.T) {
 		controller.RegisterConstructorWrapper(func() any {
 			return struct{}{}
 		})
+		controller.Startup()
 	})
 }
 
@@ -242,6 +243,7 @@ func TestWrapperFactoryWithMissingDependency(t *testing.T) {
 		controller.RegisterConstructorWrapper(func(*SomeDependency) ConstructorWrapper {
 			return newWrapperTest(nil)
 		})
+		controller.Startup()
 	})
 }
 


### PR DESCRIPTION
Allow constructor wrappers to be added at any time before `Startup()`.

Before this was the case, constructor wrappers had to be added before
the plugins they were to wrap were added via `RegisterPlugin` or
`ProvidePlugin` and that's no longer the case, relative order doesn't
matter, the module only has to have has been loaded.

